### PR TITLE
Add the ability to change the size of EBS root volume

### DIFF
--- a/mesos-master.json
+++ b/mesos-master.json
@@ -101,7 +101,7 @@
       "Default" : ""
     },
     "MasterRootVolumeSize": {
-      "Description" : "(Optional) Set the size of the root EBS volume.",
+      "Description" : "Set the size (in GB) of the root EBS volume.",
       "Type" : "Number",
       "Default" : "8"
     },

--- a/mesos-master.json
+++ b/mesos-master.json
@@ -100,6 +100,11 @@
       "Type" : "CommaDelimitedList",
       "Default" : ""
     },
+    "MasterRootVolumeSize": {
+      "Description" : "(Optional) Set the size of the root EBS volume.",
+      "Type" : "Number",
+      "Default" : "8"
+    },
     "StackCreationTimeout" : {
       "Description" : "Timeout on initial stack creation",
       "Type" : "String",
@@ -269,9 +274,14 @@
         "AssociatePublicIpAddress" : "true",
         "IamInstanceProfile" : { "Ref" : "MasterInstanceProfile" },
         "InstanceType" : { "Ref" : "InstanceType" },
+        "BlockDeviceMappings": [{
+            "DeviceName": "/dev/sda1",
+            "Ebs" : {"VolumeSize": { "Ref" : "MasterRootVolumeSize" }}
+        }],
         "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
           "#!/bin/bash -ex\n",
 
+          "resize2fs /dev/xvda1\n",
           "# Helper function\n",
           "function error_exit\n",
           "{\n",

--- a/mesos-slave.json
+++ b/mesos-slave.json
@@ -92,7 +92,7 @@
       "Default" : ""
     },
     "SlaveRootVolumeSize": {
-      "Description" : "(Optional) Set the size of the root EBS volume.",
+      "Description" : "Set the size (in GB) of the root EBS volume.",
       "Type" : "Number",
       "Default" : "8"
     },

--- a/mesos-slave.json
+++ b/mesos-slave.json
@@ -91,6 +91,11 @@
       "Type" : "CommaDelimitedList",
       "Default" : ""
     },
+    "SlaveRootVolumeSize": {
+      "Description" : "(Optional) Set the size of the root EBS volume.",
+      "Type" : "Number",
+      "Default" : "8"
+    },
     "StackCreationTimeout" : {
       "Description" : "Timeout on initial stack creation",
       "Type" : "String",
@@ -262,9 +267,14 @@
         "AssociatePublicIpAddress": "true",
         "IamInstanceProfile" : { "Ref" : "SlaveInstanceProfile" },
         "InstanceType" : { "Ref" : "InstanceType" },
+        "BlockDeviceMappings": [{
+            "DeviceName": "/dev/sda1",
+            "Ebs" : {"VolumeSize": { "Ref" : "SlaveRootVolumeSize" }}
+        }],
         "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
           "#!/bin/bash -ex\n",
 
+          "resize2fs /dev/xvda1\n",
           "# Helper function\n",
           "function error_exit\n",
           "{\n",

--- a/mesos.json
+++ b/mesos.json
@@ -87,7 +87,7 @@
       "Default" : ""
     },    
     "MasterRootVolumeSize": {
-      "Description" : "(optional) Set the size (in GB) of the master root EBS volume.",
+      "Description" : "Set the size (in GB) of the master root EBS volume.",
       "Type" : "Number",
       "Default" : "8"
     },
@@ -138,7 +138,7 @@
       "Default" : ""
     },
     "SlaveRootVolumeSize": {
-      "Description" : "(optional) Set the size (in GB) of the slave root EBS volume. Default is 8.",
+      "Description" : "Set the size (in GB) of the slave root EBS volume.",
       "Type" : "Number",
       "Default" : "8"
     },

--- a/mesos.json
+++ b/mesos.json
@@ -85,6 +85,11 @@
       "Description" : "(optional) Path within ConfigScriptS3Bucket of an executable to download and run after other boot-time provisioning (e.g., \"/path/to/script\").",
       "Type" : "String",
       "Default" : ""
+    },    
+    "MasterRootVolumeSize": {
+      "Description" : "(optional) Set the size (in GB) of the master root EBS volume.",
+      "Type" : "Number",
+      "Default" : "8"
     },
 
     "SlaveInstanceAmi" : {
@@ -131,6 +136,11 @@
       "Description" : "(optional) Resources to allocate to Mesos (as passed to --resources). To expose ports 8000-9000, for instance, you can use 'ports(*):[8000-9000, 31000-32000]'",
       "Type" : "String",
       "Default" : ""
+    },
+    "SlaveRootVolumeSize": {
+      "Description" : "(optional) Set the size (in GB) of the slave root EBS volume. Default is 8.",
+      "Type" : "Number",
+      "Default" : "8"
     },
 
     "DockerCredentials" : {
@@ -228,7 +238,8 @@
           "AdminSecurityGroup" : { "Ref" : "AdminSecurityGroup" },
           "Subnets" : { "Ref" : "Subnets" },
           "VpcId" : { "Ref" : "VpcId" },
-          "AvailabilityZones" : { "Ref" : "AvailabilityZones" }
+          "AvailabilityZones" : { "Ref" : "AvailabilityZones" },
+          "MasterRootVolumeSize" : { "Ref" : "MasterRootVolumeSize" }
         }
       }
     },
@@ -260,7 +271,8 @@
           "AdminSecurityGroup" : { "Ref" : "AdminSecurityGroup" },
           "Subnets" : { "Ref" : "Subnets" },
           "VpcId" : { "Ref" : "VpcId" },
-          "AvailabilityZones" : { "Ref" : "AvailabilityZones" }
+          "AvailabilityZones" : { "Ref" : "AvailabilityZones" },
+          "SlaveRootVolumeSize" : { "Ref" : "SlaveRootVolumeSize" }
         }
       }
     }


### PR DESCRIPTION
The default size (8GB) can be limiting when dealing with a lot of docker images. 
This creates the ability to set SlaveRootVolumeSize and MasterRootVolumeSize
